### PR TITLE
fix subject

### DIFF
--- a/private/core.rkt
+++ b/private/core.rkt
@@ -36,7 +36,7 @@
       From: @(mail-sender mail)
       To: @(string-join (mail-recipients mail) ", ")
       @~a{Cc: @(string-join (mail-cc-recipients mail) ", ")}
-      Subject: =?UTF-8?B?@(b64en-trim (mail-subject mail))?=
+      Subject: =?UTF-8?B?@(b64en (mail-subject mail))?=
       MIME-Version: 1.0
       Content-type: multipart/alternative; boundary="@boundary"
       Date: @(~t (now/moment) "E, d MMM yyyy HH:mm:ss Z")

--- a/private/utils.rkt
+++ b/private/utils.rkt
@@ -13,7 +13,7 @@
 (define (b64en str)
   (bytes->string/utf-8 (base64-encode (string->bytes/utf-8 str))))
 (define (b64en-trim str)
-  (string-trim (b64en str)))
+  (~v (string-trim (b64en str))))
 
 (define boundary
   @~a{----=_Part_@(uuid-string)})

--- a/private/utils.rkt
+++ b/private/utils.rkt
@@ -11,9 +11,7 @@
 
 
 (define (b64en str)
-  (bytes->string/utf-8 (base64-encode (string->bytes/utf-8 str))))
-(define (b64en-trim str)
-  (~v (string-trim (b64en str))))
+  (base64-encode (string->bytes/utf-8 str) #""))
 
 (define boundary
   @~a{----=_Part_@(uuid-string)})


### PR DESCRIPTION
when base64 encoded subject text includes crlf character, it will case chaos for sending emails with subject ended in advance.